### PR TITLE
プロジェクト編集ページviewの作成

### DIFF
--- a/src/components/atoms/BaseButton.tsx
+++ b/src/components/atoms/BaseButton.tsx
@@ -16,6 +16,8 @@ export const BaseButton = ({ textColor, backGroundColor, hoverColor, onClick, ..
 };
 
 const buttonStyle = (textColor: string, backGroundColor: string, hoverColor: string) => css`
+  width: 100%;
+  height: 100%;
   padding: ${styleTheme.spacing(0.5)}px ${styleTheme.spacing(1)}px;
   border-radius: ${styleTheme.borderRadius.regular}px;
   color: ${textColor};

--- a/src/components/atoms/Select.tsx
+++ b/src/components/atoms/Select.tsx
@@ -3,7 +3,7 @@ import { css } from '@emotion/react';
 import { styleTheme } from '../../theme/theme';
 import { useOpen } from '../../hooks/ui/useOpen';
 
-interface Options {
+export interface Options {
   id: string;
   value: string;
 }
@@ -88,6 +88,7 @@ const inputSelectStyle = css`
   overflow: hidden auto;
   position: absolute;
   top: 18px;
+  height: 36px;
 `;
 
 const inputTextStyle = css`
@@ -101,18 +102,20 @@ const inputTextStyle = css`
   overflow: hidden auto;
   position: absolute;
   top: 18px;
+  height: 36px;
 `;
 
 const selectStyle = css`
+  background-color: #ffffff;
   border: 1px solid ${styleTheme.colors.border.main};
   border-radius: ${styleTheme.borderRadius.regular}px;
   box-shadow: 2px 3px 4px gainsboro;
   margin: ${styleTheme.spacing(0.5)}px;
   max-width: 100%;
   width: 100%;
-  position: absolute;
-  top: 50px;
-  right: -4px;
+  position: relative;
+  top: 40px;
+  right: 4px;
   &:focus {
     outline: none;
   }

--- a/src/components/atoms/TextField.tsx
+++ b/src/components/atoms/TextField.tsx
@@ -25,6 +25,7 @@ const textFieldStyle = css`
   border-radius: ${styleTheme.borderRadius.regular}px;
   padding: ${styleTheme.spacing(1)} ${styleTheme.spacing(0.75)};
   max-width: 100%;
+  height: 36px;
 `;
 
 const labelStyle = css`

--- a/src/pages/project/ProjectEdit.tsx
+++ b/src/pages/project/ProjectEdit.tsx
@@ -4,7 +4,7 @@ import { Select } from '../../components/atoms/Select';
 import { css } from '@emotion/react';
 import { BaseButton } from '../../components/atoms/BaseButton';
 import { styleTheme } from '../../theme/theme';
-import { mediaQuery } from '../../providers/StyleThemeProvider';
+import { mobile, tablet } from '../../providers/StyleThemeProvider';
 
 // TODO プロジェクト情報更新のリクエストボディに乗せる為のstateを作成
 // TODO エンドポイントの関数のセット
@@ -14,32 +14,32 @@ import { mediaQuery } from '../../providers/StyleThemeProvider';
 export const ProjectEdit = () => {
   return (
     <div>
-      <div css={pageContainerStyle}>
+      <div css={pageWholeLayOutStyle}>
         {/* TODO モバイルサイズ ハンバーガメニューコンポーネントの挿入 */}
         <div css={headerAreaStyle}>{/* TODO グローバルナビのコンポーネントを挿入 */}</div>
 
         <div css={sidebarAreaStyle}>{/* TODO ローカルナビのコンポーネントを挿入 */}</div>
 
         <div css={contentsAreaStyle}>
-          <div css={pageNameWrapStyle}>
+          <div css={pageNameArticleStyle}>
             <h1 css={pageNameStyle}>プロジェクト編集</h1>
           </div>
 
-          <div css={projectEditWrapStyle}>
-            <form>
-              <div css={projectNameWrapStyle}>
+          <div css={projectEditArticleStyle}>
+            <form css={projectEditInformationStyle}>
+              <div css={projectNameContentStyle}>
                 <TextField value={''} onChange={() => {}} labelText={'プロジェクト名'} />
               </div>
               <div css={taskKeyWrapStyle}>
                 <TextField value={''} onChange={() => {}} labelText={'タスクキー'} />
               </div>
-              <div css={projectLeadWrapStyle}>
+              <div css={projectLeadContentStyle}>
                 <Select labelText={'プロジェクトリード'} options={[]} />
               </div>
-              <div css={contactPersonWrapStyle}>
+              <div css={contactPersonContentStyle}>
                 <Select labelText={'担当者'} options={[]} />
               </div>
-              <div css={storageButtonWrapStyle}>
+              <div css={storageButtonContentStyle}>
                 <BaseButton
                   textColor={styleTheme.colors.text.contrastText}
                   backGroundColor={styleTheme.colors.primary.main}
@@ -58,29 +58,35 @@ export const ProjectEdit = () => {
   );
 };
 
-const pageContainerStyle = css`
-  display: grid;
-  grid-template:
-    'header header header' 56px
-    'side  main main'
-    'side  main main'
-    /248px;
+const sideColumnWidth = 248; // この数字は暫定的な値
+const headerRowHeight = 56;
+
+const pageWholeLayOutStyle = css`
   height: 100vh;
   width: 100vw;
-  ${mediaQuery[0]} {
+  display: grid;
+  grid-template:
+    'header header header' ${headerRowHeight}px
+    'side  contents contents'
+    'side  contents contents'
+    / ${sideColumnWidth}px;
+  ${tablet} {
     grid-template:
       'header' 5%
-      'main' 85%
-      'footer' 5%;
+      'contents' 85%
+      'footer' 5%
+      /100%;
   }
-  ${mediaQuery[1]} {
+  ${mobile} {
     grid-template:
       'header' 10%
-      'main' 90%;
+      'contents' 90%
+      /100%;
   }
 `;
 
 const headerAreaStyle = css`
+  grid-area: header;
   width: 100%;
   z-index: 2;
   position: fixed;
@@ -88,15 +94,24 @@ const headerAreaStyle = css`
 
 const sidebarAreaStyle = css`
   grid-area: side;
-  ${mediaQuery[0]} {
+  ${tablet} {
     grid-area: footer;
   }
 `;
 
 const contentsAreaStyle = css`
-  grid-area: main;
-  ${mediaQuery[1]} {
+  grid-area: contents;
+  ${mobile} {
     padding: 0 ${styleTheme.spacing(2)}px;
+  }
+`;
+
+const pageNameArticleStyle = css`
+  position: relative;
+  top: 24px;
+  left: 40px;
+  ${mobile} {
+    display: none;
   }
 `;
 
@@ -104,55 +119,50 @@ const pageNameStyle = css`
   font-size: 2.4rem;
 `;
 
-const pageNameWrapStyle = css`
-  position: relative;
-  top: 24px;
-  left: 40px;
-  ${mediaQuery[1]} {
-    display: none;
-  }
-`;
-
-const projectEditWrapStyle = css`
+const projectEditArticleStyle = css`
   display: flex;
   justify-content: center;
   position: relative;
   top: 20%;
-  ${mediaQuery[0]} {
+  ${tablet} {
     display: flex;
     justify-content: center;
   }
 `;
 
-const projectNameWrapStyle = css`
+const projectEditInformationStyle = css`
   width: 352px;
 `;
 
+const projectNameContentStyle = css`
+  width: 100%;
+`;
+
 const taskKeyWrapStyle = css`
-  width: 352px;
+  width: 100%;
   position: relative;
   top: 16px;
 `;
 
-const projectLeadWrapStyle = css`
-  width: 352px;
+const projectLeadContentStyle = css`
+  width: 100%;
   position: relative;
   top: 32px;
 `;
 
-const contactPersonWrapStyle = css`
-  width: 352px;
+const contactPersonContentStyle = css`
+  width: 100%;
   margin-top: ${styleTheme.spacing(1)}px;
   position: relative;
   top: 76px;
 `;
 
-const storageButtonWrapStyle = css`
+const storageButtonContentStyle = css`
   width: 62px;
   margin-top: ${styleTheme.spacing(1)}px;
   position: relative;
   top: 120px;
-  ${mediaQuery[0]} {
+  ${tablet} {
     height: 36px;
     width: 352px;
   }

--- a/src/pages/project/ProjectEdit.tsx
+++ b/src/pages/project/ProjectEdit.tsx
@@ -1,0 +1,159 @@
+import React from 'react';
+import { TextField } from '../../components/atoms/TextField';
+import { Select } from '../../components/atoms/Select';
+import { css } from '@emotion/react';
+import { BaseButton } from '../../components/atoms/BaseButton';
+import { styleTheme } from '../../theme/theme';
+import { mediaQuery } from '../../providers/StyleThemeProvider';
+
+// TODO プロジェクト情報更新のリクエストボディに乗せる為のstateを作成
+// TODO エンドポイントの関数のセット
+// TODO バリデーション関数の作成
+// TODO ページ遷移の為の関数のセット
+
+export const ProjectEdit = () => {
+  return (
+    <div>
+      <div css={pageContainerStyle}>
+        {/* TODO モバイルサイズ ハンバーガメニューコンポーネントの挿入 */}
+        <div css={headerAreaStyle}>{/* TODO グローバルナビのコンポーネントを挿入 */}</div>
+
+        <div css={sidebarAreaStyle}>{/* TODO ローカルナビのコンポーネントを挿入 */}</div>
+
+        <div css={contentsAreaStyle}>
+          <div css={pageNameWrapStyle}>
+            <h1 css={pageNameStyle}>プロジェクト編集</h1>
+          </div>
+
+          <div css={projectEditWrapStyle}>
+            <form>
+              <div css={projectNameWrapStyle}>
+                <TextField value={''} onChange={() => {}} labelText={'プロジェクト名'} />
+              </div>
+              <div css={taskKeyWrapStyle}>
+                <TextField value={''} onChange={() => {}} labelText={'タスクキー'} />
+              </div>
+              <div css={projectLeadWrapStyle}>
+                <Select labelText={'プロジェクトリード'} options={[]} />
+              </div>
+              <div css={contactPersonWrapStyle}>
+                <Select labelText={'担当者'} options={[]} />
+              </div>
+              <div css={storageButtonWrapStyle}>
+                <BaseButton
+                  textColor={styleTheme.colors.text.contrastText}
+                  backGroundColor={styleTheme.colors.primary.main}
+                  hoverColor={styleTheme.colors.primary.light}
+                  onClick={() => {}}
+                  disabled={true}
+                >
+                  保存
+                </BaseButton>
+              </div>
+            </form>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const pageContainerStyle = css`
+  display: grid;
+  grid-template:
+    'header header header' 56px
+    'side  main main'
+    'side  main main'
+    /248px;
+  height: 100vh;
+  width: 100vw;
+  ${mediaQuery[0]} {
+    grid-template:
+      'header' 5%
+      'main' 85%
+      'footer' 5%;
+  }
+  ${mediaQuery[1]} {
+    grid-template:
+      'header' 10%
+      'main' 90%;
+  }
+`;
+
+const headerAreaStyle = css`
+  width: 100%;
+  z-index: 2;
+  position: fixed;
+`;
+
+const sidebarAreaStyle = css`
+  grid-area: side;
+  ${mediaQuery[0]} {
+    grid-area: footer;
+  }
+`;
+
+const contentsAreaStyle = css`
+  grid-area: main;
+  ${mediaQuery[1]} {
+    padding: 0 ${styleTheme.spacing(2)}px;
+  }
+`;
+
+const pageNameStyle = css`
+  font-size: 2.4rem;
+`;
+
+const pageNameWrapStyle = css`
+  position: relative;
+  top: 24px;
+  left: 40px;
+  ${mediaQuery[1]} {
+    display: none;
+  }
+`;
+
+const projectEditWrapStyle = css`
+  display: flex;
+  justify-content: center;
+  position: relative;
+  top: 20%;
+  ${mediaQuery[0]} {
+    display: flex;
+    justify-content: center;
+  }
+`;
+
+const projectNameWrapStyle = css`
+  width: 352px;
+`;
+
+const taskKeyWrapStyle = css`
+  width: 352px;
+  position: relative;
+  top: 16px;
+`;
+
+const projectLeadWrapStyle = css`
+  width: 352px;
+  position: relative;
+  top: 32px;
+`;
+
+const contactPersonWrapStyle = css`
+  width: 352px;
+  margin-top: ${styleTheme.spacing(1)}px;
+  position: relative;
+  top: 76px;
+`;
+
+const storageButtonWrapStyle = css`
+  width: 62px;
+  margin-top: ${styleTheme.spacing(1)}px;
+  position: relative;
+  top: 120px;
+  ${mediaQuery[0]} {
+    height: 36px;
+    width: 352px;
+  }
+`;

--- a/src/providers/StyleThemeProvider.tsx
+++ b/src/providers/StyleThemeProvider.tsx
@@ -7,7 +7,7 @@ interface Props {
   children: ReactNode;
 }
 
-export const breakPoint = [1023, 767];
+export const breakPoint = [1024, 768];
 export const mediaQuery = breakPoint.map((bp: number) => `@media(max-width: ${bp}px)`);
 
 export const StyleThemeProvider: VFC<Props> = ({ children }) => {

--- a/src/providers/StyleThemeProvider.tsx
+++ b/src/providers/StyleThemeProvider.tsx
@@ -7,8 +7,10 @@ interface Props {
   children: ReactNode;
 }
 
-export const breakPoint = [1024, 768];
-export const mediaQuery = breakPoint.map((bp: number) => `@media(max-width: ${bp}px)`);
+export const { tablet, mobile } = {
+  tablet: `@media(max-width: 1024px)`,
+  mobile: `@media(max-width: 768px)`,
+};
 
 export const StyleThemeProvider: VFC<Props> = ({ children }) => {
   return (

--- a/src/providers/StyleThemeProvider.tsx
+++ b/src/providers/StyleThemeProvider.tsx
@@ -1,11 +1,14 @@
 import React, { ReactNode, VFC } from 'react';
 import emotionReset from 'emotion-reset';
 import { Global, css, ThemeProvider } from '@emotion/react';
-import { styleTheme } from './../theme/theme';
+import { styleTheme } from '../theme/theme';
 
 interface Props {
   children: ReactNode;
 }
+
+export const breakPoint = [1023, 767];
+export const mediaQuery = breakPoint.map((bp: number) => `@media(max-width: ${bp}px)`);
 
 export const StyleThemeProvider: VFC<Props> = ({ children }) => {
   return (


### PR DESCRIPTION
# やったこと

- プロジェクト編集ページのview部分の作成
ページの全体的な構成の把握の目的の為、ページview部分のみ作成しました。

- 使用コンポーネントの修正
ページレイアウト時にデザイン仕様を満たしてなかった為、修正実施してます。

- mediaQueryの設定
ブレイクポイント設定は
タブレット対応の為max-width 1024px、モバイルを想定でのmax-width768pxに設定しました。

# やらないこと

- 編集ページのバリデーション実装
以下の実装後に実施します。

- ページ遷移の関数実装
routerの設定後に実施します。

- API関数の設置
APIの関数作成後実施します。

- 各テキストフィールドのevent handler作成
API、router設定後実施します。

- ローカル、グローバルナビの実装
コンポーネント作成後に実装実施します。

# スクリーンショット

<img width="468" alt="スクリーンショット 2022-01-17 17 05 52" src="https://user-images.githubusercontent.com/77338175/150388685-2df03a6b-08b9-4c0a-8ca3-181196ef9975.png">
<img width="459" alt="スクリーンショット 2022-01-17 17 06 29" src="https://user-images.githubusercontent.com/77338175/150388696-9b826d6a-1524-45bc-ad41-fe5ad2594810.png">
<img width="1792" alt="スクリーンショット 2022-01-17 17 06 42（2）" src="https://user-images.githubusercontent.com/77338175/150388701-30aa68b9-32fb-4516-8692-6e0741728e5e.png">

＃ その他

タブレットの縦版でのfooterにローカルナビ配置するかは検討中の為、仮で下に設置しております。

